### PR TITLE
fix: Correction in the description on meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <meta property="og:site_name"   content="thecyberhub.org">
     <meta property="og:url"         content="https://user-images.githubusercontent.com/44284877/194150142-1df54766-b8bb-4d9c-9e86-26907e324551.gif">
     <meta property="og:title"       content=" Cyber Security Made Easy.">
-    <meta property="og:description" content="Thecyberhub is the best platform for hacker to learn cybersecurity for free.">
+    <meta property="og:description" content="Thecyberhub is the best platform for hackers to learn cybersecurity for free.">
 
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">


### PR DESCRIPTION
A common noun  in singular number always requires an article before it but it is better to leave this in plural form

--Thecyberhub is the best platform for hacker to learn cybersecurity for free--
 should be 
--Thecyberhub is the best platform for hackers to learn cybersecurity for free--



