### PR TITLE
fix: Alignment issue on the events page

### DIFF
--- a/src/components/Events/EventsElement.jsx
+++ b/src/components/Events/EventsElement.jsx
@@ -32,7 +32,7 @@ export const UpComingEventsContainer = styled.div`
 `;
 
 export const EventsHeading = styled.h1`
-  margin: 0 0 10px 0
+  margin: 0 0 30px 0
 `;
 
 export const PastEventsContainer = styled.div`

--- a/src/components/Events/OnGoingEvents/OnGoingEventsElements.jsx
+++ b/src/components/Events/OnGoingEvents/OnGoingEventsElements.jsx
@@ -10,8 +10,12 @@ export const OnGoingEventsContainer = styled.div`
   border: 1px solid #ffffff0d;
   border-radius: 10px;
   background-color: #0d1117;
-  margin: 20px 20px;
+  margin: 0 20px 20px 0;
   padding: 15px 20px;
+
+  @media screen and (max-width: 768px) {
+    margin: 0 0 20px 0;
+  }
 `
 
 export const OnGoingEvents_Image = styled.img`

--- a/src/components/Events/UpComingEvents/UpComingEventsElements.jsx
+++ b/src/components/Events/UpComingEvents/UpComingEventsElements.jsx
@@ -9,10 +9,11 @@ export const UpComingEventsContainer = styled.div`
   border: 1px solid #ffffff0d;
   border-radius: 10px;
   background-color: #0d1117;
-  margin: 20px 20px 20px 0;
+  margin: 0 20px 20px 0;
   padding: 15px 20px;
 
   @media screen and (max-width: 768px) {
+    margin: 0 0 20px 0;
     width: 100%;
   }
 `


### PR DESCRIPTION
Closes #222 

## Fixes Issue
Alignment issue on the events page for upcoming, today, and past events.

##Screenshot
<img width="1105" alt="Screenshot 2022-10-19 at 12 49 57 PM" src="https://user-images.githubusercontent.com/41188167/196631114-2a4ec56a-3f45-44c7-af6f-d51a1e8aa379.png">
