### PR TITLE
fix: allow buttons to transition without affecting other elements

### DIFF
--- a/src/components/Footer/FooterElements.jsx
+++ b/src/components/Footer/FooterElements.jsx
@@ -198,7 +198,7 @@ export const SocialIconLinkTwitter = styled.a`
   &:hover {
     color: #1d9bf0;
     transition: 0.3s ease-out;
-    font-size: 30px;
+    scale: 1.2;
   }
 `;
 
@@ -209,7 +209,7 @@ export const SocialIconLinkGithub = styled.a`
   &:hover {
     color: #f0f6fc;
     transition: 0.3s ease-out;
-    font-size: 30px;
+    scale: 1.2;
   }
 `;
 
@@ -220,7 +220,7 @@ export const SocialIconLinkDiscord = styled.a`
   &:hover {
     color: #5865f2;
     transition: 0.3s ease-out;
-    font-size: 30px;
+    scale: 1.2;
   }
 `;
 export const SocialIconLinkInstagram = styled.a`
@@ -230,7 +230,7 @@ export const SocialIconLinkInstagram = styled.a`
   &:hover {
     color: #b83993;
     transition: 0.3s ease-out;
-    font-size: 30px;
+    scale: 1.2;
   }
 `;
 
@@ -247,7 +247,7 @@ export const SocialLogo = styled(RouterLink)`
 
   :hover {
     color: #20c20e;
-    font-size: 1.6rem;
+    scale: 1.2;
     transition: 0.3s ease-out;
   }
 `;

--- a/src/components/MixComponents/Buttons/ButtonElements.jsx
+++ b/src/components/MixComponents/Buttons/ButtonElements.jsx
@@ -35,7 +35,8 @@ export const GlowingButton = styled(LinkRouter)`
     transition: all 0.2s ease-in-out;
     background: transparent;
     border-color: #343434;
-    font-size: 18px;
+    scale: 1.1;
+    font-size: 16px;
   }
 `;
 export const Button = styled(ScrollLink)`
@@ -62,7 +63,8 @@ export const Button = styled(ScrollLink)`
     transition: all 0.2s ease-in-out;
     background: transparent;
     border-color: #343434;
-    font-size: 18px;
+    scale: 1.1;
+    font-size: 16px;
   }
 
   @media screen and (max-width: 600px) {
@@ -95,7 +97,8 @@ export const RedirectButton = styled.a`
     transition: all 0.2s ease-in-out;
     background: transparent;
     border-color: #343434;
-    font-size: 18px;
+    scale: 1.1;
+    font-size: 16px;
   }
 `;
 export const RouterButton = styled(RouterLink)`
@@ -122,7 +125,8 @@ export const RouterButton = styled(RouterLink)`
     transition: all 0.2s ease-in-out;
     background: transparent;
     border-color: #343434;
-    font-size: 18px;
+    scale: 1.1;
+    font-size: 16px;
   }
 `;
 export const FilledButton = styled(RouterButton)`
@@ -161,7 +165,8 @@ export const ButtonLink = styled.a`
     background: transparent;
     color: #20c20e;
     border-color: #343434;
-    font-size: 18px;
+    scale: 1.1;
+    font-size: 16px;
   }
 `;
 


### PR DESCRIPTION


<!-- If your PR fixes an open issue, use `Closes #23` to link your PR with the issue. #23 stands for the issue number you are fixing -->

## Fixes Issue
Example: Closes #232

## Changes proposed
Add scale and optional increase to font size on hover to make button elements (or any element actually)  scale without causing other elements to move



<!-- --------------- -->
<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
Correct ways to mark a box:
[X] - Correct; marked as done
[X] - Correct; marked as done

Incorrect ways to mark a box:
[ ] - Incorrect; marked as not done
[x ] - Incorrect;
[ x ] - Incorrect;
[ x] - Incorrect;
-->

## Code of Conduct

- [x] By submitting this pull request, I confirm I've read and complied with the [CoC](https://github.com/thecyberworld/Support/blob/main/CODE_OF_CONDUCT.md) 🖖

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

---

You can also join our [Discord](https://discord.gg/QHBPq6xP5p) community.
Feel free to check out other cool repositories of the [Thecyberworld](https://github.com/thecyberworld).
Join the Thecyberworld GitHub Organisation by raising an [issue](https://github.com/thecyberworld/Support/issues/new?assignees=&labels=invite+me+to+the+organisation&template=invitation.yml&title=Please+invite+me+to+the+GitHub+Community+Organization) (you will be sent an invitation).
